### PR TITLE
Meeting notes for 2023-09-07

### DIFF
--- a/meetings/2023-09-07/README.md
+++ b/meetings/2023-09-07/README.md
@@ -1,0 +1,35 @@
+# Special Interest Group in Robot Interoperability
+07 September 2023
+[Meeting Recording](https://vimeo.com/866899277) | [Meeting Announcement](https://discourse.ros.org/t/special-interest-group-in-interoperability/33081)
+ 
+## Agenda
+- Grey (Open-RMF): Intro and presentation of the Interoperability Interest Group.
+[Slides here](https://docs.google.com/presentation/d/1mqAuq4llmWopb-5RgX-_C8QjSCvfPf_KQIr3_AlNvjE/edit?usp=sharing) (Min. 00:00).
+- Daniel Theobald (MassRobotics Interop): "Interoperability: What It Is and Why We Need it."
+[Slides here](https://docs.google.com/presentation/d/1cFZXvimJdHJOpY8TzB1lPHmiLmnA1Gpi/edit?usp=drive_link&ouid=105800562763083176452&rtpof=true&sd=true) (Min. 10:45)
+- Grey (Open-RMF): "Open-RMF Brief Overview."
+[Slides here](https://docs.google.com/presentation/d/1tDYIunOreVIWiqeDfgBrNAE8M3iZ-tRbpegyiWsPxlg/edit?usp=drive_link) (Min. 23:48)
+
+## Administivia
+
+- Meetings will run monthly for 1 hour with announcements on the [ROS discourse](https://discourse.ros.org).
+- Github org for collaboration: [https://github.com/osrf-sig-interoperability](https://github.com/osrf-sig-interoperability)
+ 
+## Discussion
+
+- Gillaume Autran worked with VDA5050 so he gave and commented how it targets AMRs with a bit of AGVs support. (Min. 40:40)
+- Grey and Daniel commented on how Open-RMF, MassRobotics Interop and VDA5050 can complement each other. (Min. 41:30)
+  - Grey answered follow up questions on possible collaborations (Min. 47:28)
+- Grey answered what interoperability means in the context of Open-RMF and Daniel answered for MassRobotics Interop. (Min. 48:05)
+- Grey and Daniel answered for network requirements for Open-RMF and MassRobotics Interop respectively. (Min. 52:00)
+- Grey commented on the differences on the future event driven simulation expected for RMF vs scaling gazebo. (Min. 54:04)
+- Grey commented on how to deal with fleetstate semantics for system validation. (Min. 55:23)
+- Daniel asked regarding having physics turned on on simulation on a per robot level and Grey commented 
+regarding the Gazebo Trivial Physics Engine and how extremely hard it would be to combine that with actual physics. (Min. 56:27)
+- Daniel addressed how the VDA5050 standard efforts will correlate with MassRobotics work. (Min 59:35)
+- Grey commented on the workflow on how to deploy Open-RMF, specifically how to obtain the map using the traffic editor. (Min. 60:00)
+- Grey commented on possible workflows for Open-RMF when remapping environments and handling transforms. (Min: 1:07:00)
+- Grey explained how the easy full control API makes easier custom actions although there are more sophisticated
+ways to deal with task customization to come. (Min. 1:11:45)
+- Grey addressed how Open-RMF some nodes are already robust to teardown and restart and others still need work to get there. (Min. 1:15:00)
+


### PR DESCRIPTION
Adding meeting notes for the interoperability interest group held on 2023-09-07.

Relevant discourse announcement: https://discourse.ros.org/t/special-interest-group-in-interoperability/33081